### PR TITLE
Add support for loading and dumping manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ googletest-build/*
 
 # Logging
 data/leodb-lob.log
+*.log
+
+# LeoDB files
+*.leodb
 
 # Executables created
 leodb

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # LeoDB
 TBA
+
+## To Run Main.cpp

--- a/main.cpp
+++ b/main.cpp
@@ -9,15 +9,13 @@ int main() {
 //    Key<int> one (5);
 //    Value<int> val (4);
 //    Key<int> two (6);
-    DB<int, int> test;
-    DB<int, int> test2;
-    bool ret = test.put(Key<int>(1), Value<int>(3));
-    test2.LOAD_FROM_FILE("cmake-build-debug/data.txt");
+    DB<int, int> leodb;
+    leodb.DUMP_MANIFEST();
     //test.CLOSE();
-//    test.put(Key<int>(10), Value<int>(32));
+    //    test.put(Key<int>(10), Value<int>(32));
+//    leodb.put(1, 1);
+    std::cout << (int) leodb.getHeight();
 
-    std::cout<<test2.get(Key<int>(1)).getItem();
-    loguru::add_file("data/leodb-lob.log", loguru::Append, loguru::Verbosity_MAX);
-    LOG_F(INFO, "Hello log file!");
+
     return 0;
 }

--- a/src/data/value.cpp
+++ b/src/data/value.cpp
@@ -3,7 +3,8 @@
 template <typename U>
 U Value<U>::getItem() {
     /*
-     *
+     * Function getItem: Returns the item inside the value object
+     * Returns: Item of type U
      */
     return item;
 }

--- a/src/data/value.h
+++ b/src/data/value.h
@@ -17,7 +17,7 @@ public:
     bool operator < (Value other){ return item < other.getItem(); }
     bool operator >= (Value other){ return item >= other.getItem(); }
     bool operator <= (Value other) { return item <= other.getItem(); };
-     U getItem();
+    U getItem();
 private:
     U item;
 

--- a/src/db.h
+++ b/src/db.h
@@ -4,9 +4,11 @@
 #include <unordered_map>
 #include <fstream>
 #include <sstream>
+#include <iostream>
 #include <data/key.h>
 #include <data/value.h>
 #include <data/entry.h>
+#include <loguru.cpp>
 
 typedef enum status{
     OPEN = 0,
@@ -15,10 +17,17 @@ typedef enum status{
     ERROR = 400,
 } DB_STATUS;
 
+// Global Constants
+std::string DATA_FOLDER_PATH = "data";
+std::string LOGGER_PATH = DATA_FOLDER_PATH + "/leodb-log.log";
+
 template <class T, class U>
 class DB {
 public:
-    DB() = default;
+    // Constructor
+    DB(std::string file_path=DATA_FOLDER_PATH, std::string logger_path=LOGGER_PATH);
+
+    // Basic Operations
     bool put(int key, int value);
     bool put(Key<T> key, Value<U> value);
     bool del(Key<T> key);
@@ -28,18 +37,30 @@ public:
     int max(bool keys=true);
     float avg(bool keys=true);
     float stddev(bool keys=true);
-    int size();
+
+    // Logistics
     DB_STATUS db_status;
     DB_STATUS OPEN_FILE();
     bool CLOSE();
-    bool LOAD_FROM_FILE(const std::string& file_name);
+    bool LOAD_FROM_FILE(std::string file_name);
+    bool DUMP_MANIFEST(std::string file_path=DATA_FOLDER_PATH);
+    bool LOAD_MANIFEST(std::string file_path=DATA_FOLDER_PATH);
+
+    // DB Information
+    int size();
+    int getHeight();
+
 private:
-    std::unordered_map<int, Entry<T, U> > table;
+    // Private Variables
+    int MEMORY_THRESHOLD;
     int totalKeys;
+    std::unordered_map<int, Entry<T, U> > table;
+    std::unordered_map<std::string, std::string> manifest;
     std::ofstream file;
-    int MEMORY_THRESHOLD = 10000;
+
+    // Private Function
     bool WRITE_TO_FILE();
-    // maybe some more stuff...
+    std::string initialize_manifest();
 };
 
 #endif //LEODB_DB_H


### PR DESCRIPTION
Manifest will be located at `data/manifest.leodb`
This PR adds support for initially creating that file, and then loading and dumping to that file. 

Created a unordered_map<string, string> called `manifest` under the DB class 